### PR TITLE
Add: セッション認証用のミドルウェアを追加

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"net/http"
+
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
 
 	"github.com/shii-park/friends/internal/handler"
+	"github.com/shii-park/friends/internal/middleware"
 )
 
 func main() {
@@ -16,6 +19,11 @@ func main() {
 	r.Use(sessions.Sessions("mysession", store))
 
 	r.POST("/register", handler.RegisterHandler)
+
+	//保護されたエンドポイントの動作検証(後々削除)
+	r.GET("/ping", middleware.AuthRequired(), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"message": "pong"})
+	})
 
 	//ポート8080番でリッスン
 	r.Run()

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,16 @@ module github.com/shii-park/friends
 
 go 1.26.0
 
-require github.com/gin-gonic/gin v1.11.0
+require (
+	github.com/gin-gonic/gin v1.11.0
+	github.com/stretchr/testify v1.11.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
 
 require (
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,7 @@ golang.org/x/tools v0.34.0 h1:qIpSLOxeCYGg9TrcJokLBG4KFA6d795g0xkBkiESGlo=
 golang.org/x/tools v0.34.0/go.mod h1:pAP9OwEaY1CAW3HOmg3hLZC5Z0CCmzjAF2UQMSqNARg=
 google.golang.org/protobuf v1.36.9 h1:w2gp2mA27hUeUzj9Ex9FBjsBm40zfaDtEWow293U7Iw=
 google.golang.org/protobuf v1.36.9/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -1,0 +1,20 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-gonic/gin"
+)
+
+func AuthRequired() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		session := sessions.Default(c)
+		userID := session.Get("userID") //keyはRegisterHandler()と統一する
+		if userID == nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "認証が必要です"})
+			return
+		}
+		c.Next()
+	}
+}

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// AuthRequiredはユーザーが認証済であるかを検証するミドルウェアです
 func AuthRequired() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		session := sessions.Default(c)

--- a/internal/middleware/auth.go
+++ b/internal/middleware/auth.go
@@ -16,6 +16,7 @@ func AuthRequired() gin.HandlerFunc {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "認証が必要です"})
 			return
 		}
+		c.Set("userID", userID)
 		c.Next()
 	}
 }

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -1,0 +1,66 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/shii-park/friends/internal/middleware"
+
+	"github.com/gin-contrib/sessions"
+	"github.com/gin-contrib/sessions/cookie"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupRouter(userID any) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	store := cookie.NewStore([]byte("test-secret"))
+	r.Use(sessions.Sessions("mysession", store))
+
+	// セッションにuserIDをセットするエンドポイント（テスト用）
+	r.GET("/set-session", func(c *gin.Context) {
+		session := sessions.Default(c)
+		if userID != nil {
+			session.Set("userID", userID)
+			session.Save()
+		}
+		c.Status(http.StatusOK)
+	})
+
+	r.GET("/protected", middleware.AuthRequired(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	return r
+}
+
+func TestAuthRequired_正常系(t *testing.T) {
+	r := setupRouter("user-123")
+
+	// セッションCookieを取得
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/set-session", nil)
+	r.ServeHTTP(w, req)
+	cookie := w.Result().Header.Get("Set-Cookie")
+
+	// 保護されたエンドポイントにCookieつきでアクセス
+	w2 := httptest.NewRecorder()
+	req2, _ := http.NewRequest("GET", "/protected", nil)
+	req2.Header.Set("Cookie", cookie)
+	r.ServeHTTP(w2, req2)
+
+	assert.Equal(t, http.StatusOK, w2.Code)
+}
+
+func TestAuthRequired_セッション情報なし(t *testing.T) {
+	r := setupRouter(nil)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/protected", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -25,7 +25,10 @@ func setupRouter(userID any) *gin.Engine {
 		session := sessions.Default(c)
 		if userID != nil {
 			session.Set("userID", userID)
-			session.Save()
+			err := session.Save()
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err})
+			}
 		}
 		c.Status(http.StatusOK)
 	})
@@ -42,13 +45,19 @@ func TestAuthRequired_正常系(t *testing.T) {
 
 	// セッションCookieを取得
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/set-session", nil)
+	req, err := http.NewRequest("GET", "/set-session", nil)
+	if err != nil {
+		t.Logf("正常系テストの1つ目のhttpリクエストの作成失敗: %v", err)
+	}
 	r.ServeHTTP(w, req)
 	cookie := w.Result().Header.Get("Set-Cookie")
 
 	// 保護されたエンドポイントにCookieつきでアクセス
 	w2 := httptest.NewRecorder()
-	req2, _ := http.NewRequest("GET", "/protected", nil)
+	req2, err := http.NewRequest("GET", "/protected", nil)
+	if err != nil {
+		t.Logf("正常系テストの2つ目のhttpリクエストの作成失敗: %v", err)
+	}
 	req2.Header.Set("Cookie", cookie)
 	r.ServeHTTP(w2, req2)
 
@@ -59,7 +68,10 @@ func TestAuthRequired_セッション情報なし(t *testing.T) {
 	r := setupRouter(nil)
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/protected", nil)
+	req, err := http.NewRequest("GET", "/protected", nil)
+	if err != nil {
+		t.Logf("セッション情報なしテストのhttpリクエストの作成失敗: %v", err)
+	}
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
リクエストにセッション情報が存在することを認証するミドルウェアを追加しました
## 変更の理由・背景
- アクセスしているユーザーが本人であるか確かめるため

## 変更内容
- セッション認証用ミドルウェアAuthRequired()追加
- AuthRequired()の動作を検証するテストコード追加
- main.goに保護されたエンドポイントのサンプルを追加(他のエンドポイント作り次第削除予定)

## スクリーンショット（UI変更がある場合）

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 