### PR TITLE
Add: ユーザー新規作成ハンドラにDB保存処理とセッション保存処理を追加

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -42,7 +42,6 @@ func main() {
 
 	// sqlcセットアップ
 	queries := sqlc.New(dbConn)
-	_ = queries // 未使用によるコンパイルエラー回避のために一時的に代入しています．クエリが必要になった時に，queriesからもらってください．その際にこの行は削除してください．
 
 	r := gin.Default()
 
@@ -52,7 +51,7 @@ func main() {
 
 	// 認証なしエンドポイント
 	// 新規登録
-	r.POST("/register", handler.RegisterHandler)
+	r.POST("/register", handler.RegisterHandler(queries))
 
 	// 認証が必要なエンドポイント
 	auth := r.Group("/")

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -11,10 +11,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/joho/godotenv"
 	"github.com/shii-park/friends/internal/db"
-	"github.com/shii-park/friends/internal/sqlc"
-
 	"github.com/shii-park/friends/internal/handler"
 	"github.com/shii-park/friends/internal/middleware"
+	"github.com/shii-park/friends/internal/service"
+	"github.com/shii-park/friends/internal/sqlc"
 )
 
 func main() {
@@ -43,6 +43,9 @@ func main() {
 	// sqlcセットアップ
 	queries := sqlc.New(dbConn)
 
+	// serviceセットアップ
+	registerSvc := service.NewRegisterService(queries)
+
 	r := gin.Default()
 
 	//TODO: クッキーの秘密鍵や名前の変更
@@ -51,7 +54,7 @@ func main() {
 
 	// 認証なしエンドポイント
 	// 新規登録
-	r.POST("/register", handler.RegisterHandler(queries))
+	r.POST("/register", handler.RegisterHandler(registerSvc))
 
 	// 認証が必要なエンドポイント
 	auth := r.Group("/")

--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -1,1 +1,0 @@
-package handler

--- a/internal/handler/register_handler.go
+++ b/internal/handler/register_handler.go
@@ -18,8 +18,8 @@ func RegisterHandler(svc *service.RegisterService) gin.HandlerFunc {
 			Username       string `json:"userName" binding:"required"`
 			Icon           string `json:"icon,omitempty"`
 			ProfileMessage string `json:"profileMsg,omitempty"`
-			Birthmonth     int    `json:"birthmonth" binding:"required"`
-			Birthday       int    `json:"birthday" binding:"required"`
+			Birthmonth     int    `json:"birthmonth,omitempty"`
+			Birthday       int    `json:"birthday,omitempty"`
 		}
 
 		if err := c.ShouldBindBodyWithJSON(&json); err != nil {

--- a/internal/handler/register_handler.go
+++ b/internal/handler/register_handler.go
@@ -27,7 +27,7 @@ func RegisterHandler(svc *service.RegisterService) gin.HandlerFunc {
 			return
 		}
 
-		//DBにユーザーデータを保存
+		// DBにユーザーデータを保存
 		user, err := svc.RegisterUser(c.Request.Context(), json.Username, json.Icon, json.ProfileMessage, json.Birthmonth, json.Birthday)
 		if err != nil {
 			if errors.Is(err, errs.ErrUserNameRequired) || errors.Is(err, errs.ErrInvalidBirthday) {

--- a/internal/handler/register_handler.go
+++ b/internal/handler/register_handler.go
@@ -1,10 +1,12 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
+	"github.com/shii-park/friends/internal/errs"
 	"github.com/shii-park/friends/internal/service"
 )
 
@@ -28,7 +30,11 @@ func RegisterHandler(svc *service.RegisterService) gin.HandlerFunc {
 		//DBにユーザーデータを保存
 		user, err := svc.RegisterUser(c.Request.Context(), json.Username, json.Icon, json.ProfileMessage, json.Birthmonth, json.Birthday)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			if errors.Is(err, errs.ErrUserNameRequired) || errors.Is(err, errs.ErrInvalidBirthday) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			} else {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "サーバーエラーが発生しました"})
+			}
 			return
 		}
 

--- a/internal/handler/register_handler.go
+++ b/internal/handler/register_handler.go
@@ -42,6 +42,7 @@ func RegisterHandler(svc *service.RegisterService) gin.HandlerFunc {
 		session := sessions.Default(c)
 		session.Set("userID", user.ID)
 		if err := session.Save(); err != nil {
+			_ = svc.DeleteUser(c.Request.Context(), user.ID)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}

--- a/internal/handler/register_handler.go
+++ b/internal/handler/register_handler.go
@@ -1,46 +1,78 @@
 package handler
 
 import (
-	"fmt"
+	"database/sql"
 	"net/http"
 
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 	"github.com/shii-park/friends/internal/domain"
+	"github.com/shii-park/friends/internal/sqlc"
 )
 
 // RegisterHandler はユーザー新規登録を処理するハンドラーです
 // ユーザー情報をデータベースに保存し，セッションを保存します．
-func RegisterHandler(c *gin.Context) {
-	var json struct {
-		Username       string `json:"userName" binding:"required"`
-		Icon           string `json:"icon,omitempty"`
-		ProfileMessage string `json:"profileMsg,omitempty"`
-		Birthmonth     int    `json:"birthmonth" binding:"required"`
-		Birthday       int    `json:"birthday" binding:"required"`
+func RegisterHandler(queries *sqlc.Queries) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var json struct {
+			Username       string `json:"userName" binding:"required"`
+			Icon           string `json:"icon,omitempty"`
+			ProfileMessage string `json:"profileMsg,omitempty"`
+			Birthmonth     int    `json:"birthmonth" binding:"required"`
+			Birthday       int    `json:"birthday" binding:"required"`
+		}
+
+		if err := c.ShouldBindBodyWithJSON(&json); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		user, err := domain.NewUser(json.Username, json.Icon, json.ProfileMessage, json.Birthmonth, json.Birthday)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		// ユーザー情報をDBに保存する
+		err = queries.CreateUser(c.Request.Context(), sqlc.CreateUserParams{
+			UserID:   user.ID,
+			UserName: user.Name,
+			IconUrl: sql.NullString{
+				String: user.Icon,
+				Valid:  user.Icon != "",
+			},
+			ProfileMessage: sql.NullString{
+				String: user.ProfileMessage,
+				Valid:  user.ProfileMessage != "",
+			},
+			BirthMonth: sql.NullInt16{
+				Int16: int16(user.Birthmonth),
+				Valid: true,
+			},
+			BirthDay: sql.NullInt16{
+				Int16: int16(user.Birthday),
+				Valid: true,
+			},
+			LatestLoginDate: sql.NullTime{
+				Time:  user.LatestLoginAt,
+				Valid: true,
+			},
+			StreakLoginDays: int32(user.StreakLogin),
+		})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		// セッション保存
+		session := sessions.Default(c)
+		session.Set("userID", user.ID)
+		if err := session.Save(); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		//TODO: フロントへのレスポンスは話し合って調整する
+		c.JSON(http.StatusOK, gin.H{"message": "ユーザ登録が完了しました"})
 	}
-
-	session := sessions.Default(c)
-
-	if err := c.ShouldBindBodyWithJSON(&json); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
-	user, err := domain.NewUser(json.Username, json.Icon, json.ProfileMessage, json.Birthmonth, json.Birthday)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
-	//TODO: ユーザー情報をDBに保存する処理を追加
-	//TODO: 下のPrintlnを削除(未使用の変数があるとエラーが出るので置いています)
-	fmt.Println(user)
-
-	//TODO: セッション保存処理を追加
-	// session.Set("userID",user.ID)
-
-	//TODO: フロントへのレスポンスは話し合って調整する
-	c.JSON(http.StatusOK, gin.H{"message": "ユーザ登録が完了しました"})
-
 }

--- a/internal/handler/register_handler.go
+++ b/internal/handler/register_handler.go
@@ -41,6 +41,6 @@ func RegisterHandler(svc *service.RegisterService) gin.HandlerFunc {
 		}
 
 		//TODO: フロントへのレスポンスは話し合って調整する
-		c.JSON(http.StatusOK, gin.H{"message": "ユーザ登録が完了しました"})
+		c.JSON(http.StatusOK, gin.H{"message": "ユーザー登録が完了しました"})
 	}
 }

--- a/internal/handler/register_handler.go
+++ b/internal/handler/register_handler.go
@@ -1,18 +1,16 @@
 package handler
 
 import (
-	"database/sql"
 	"net/http"
 
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
-	"github.com/shii-park/friends/internal/domain"
-	"github.com/shii-park/friends/internal/sqlc"
+	"github.com/shii-park/friends/internal/service"
 )
 
 // RegisterHandler はユーザー新規登録を処理するハンドラーです
 // ユーザー情報をデータベースに保存し，セッションを保存します．
-func RegisterHandler(queries *sqlc.Queries) gin.HandlerFunc {
+func RegisterHandler(svc *service.RegisterService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var json struct {
 			Username       string `json:"userName" binding:"required"`
@@ -27,40 +25,10 @@ func RegisterHandler(queries *sqlc.Queries) gin.HandlerFunc {
 			return
 		}
 
-		user, err := domain.NewUser(json.Username, json.Icon, json.ProfileMessage, json.Birthmonth, json.Birthday)
+		//DBにユーザーデータを保存
+		user, err := svc.RegisterUser(c.Request.Context(), json.Username, json.Icon, json.ProfileMessage, json.Birthmonth, json.Birthday)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-			return
-		}
-
-		// ユーザー情報をDBに保存する
-		err = queries.CreateUser(c.Request.Context(), sqlc.CreateUserParams{
-			UserID:   user.ID,
-			UserName: user.Name,
-			IconUrl: sql.NullString{
-				String: user.Icon,
-				Valid:  user.Icon != "",
-			},
-			ProfileMessage: sql.NullString{
-				String: user.ProfileMessage,
-				Valid:  user.ProfileMessage != "",
-			},
-			BirthMonth: sql.NullInt16{
-				Int16: int16(user.Birthmonth),
-				Valid: true,
-			},
-			BirthDay: sql.NullInt16{
-				Int16: int16(user.Birthday),
-				Valid: true,
-			},
-			LatestLoginDate: sql.NullTime{
-				Time:  user.LatestLoginAt,
-				Valid: true,
-			},
-			StreakLoginDays: int32(user.StreakLogin),
-		})
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
 

--- a/internal/handler/register_handler.go
+++ b/internal/handler/register_handler.go
@@ -18,8 +18,8 @@ func RegisterHandler(svc *service.RegisterService) gin.HandlerFunc {
 			Username       string `json:"userName" binding:"required"`
 			Icon           string `json:"icon,omitempty"`
 			ProfileMessage string `json:"profileMsg,omitempty"`
-			Birthmonth     int    `json:"birthmonth,omitempty"`
-			Birthday       int    `json:"birthday,omitempty"`
+			Birthmonth     int    `json:"birthmonth" binding:"required"`
+			Birthday       int    `json:"birthday" binding:"required"`
 		}
 
 		if err := c.ShouldBindBodyWithJSON(&json); err != nil {

--- a/internal/handler/register_handler.go
+++ b/internal/handler/register_handler.go
@@ -46,7 +46,7 @@ func RegisterHandler(svc *service.RegisterService) gin.HandlerFunc {
 			return
 		}
 
-		//TODO: フロントへのレスポンスは話し合って調整する
+		// TODO: フロントへのレスポンスは話し合って調整する
 		c.JSON(http.StatusOK, gin.H{"message": "ユーザー登録が完了しました"})
 	}
 }

--- a/internal/handler/register_handler.go
+++ b/internal/handler/register_handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 	"github.com/shii-park/friends/internal/domain"
 )
@@ -19,8 +20,7 @@ func RegisterHandler(c *gin.Context) {
 		Birthday       int    `json:"birthday" binding:"required"`
 	}
 
-	//TODO: DB保存処理が完成したら下のコメントアウトを解除
-	// session := sessions.Default(c)
+	session := sessions.Default(c)
 
 	if err := c.ShouldBindBodyWithJSON(&json); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/internal/service/register_service.go
+++ b/internal/service/register_service.go
@@ -64,3 +64,11 @@ func (s *RegisterService) RegisterUser(ctx context.Context, name string, icon st
 
 	return user, nil
 }
+
+func (s *RegisterService) DeleteUser(c context.Context, userID string) error {
+	id, err := uuid.Parse(userID)
+	if err != nil {
+		return err
+	}
+	return s.queries.DeleteUser(c, id)
+}

--- a/internal/service/register_service.go
+++ b/internal/service/register_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 
+	"github.com/google/uuid"
 	"github.com/shii-park/friends/internal/domain"
 	"github.com/shii-park/friends/internal/sqlc"
 )
@@ -23,8 +24,13 @@ func (s *RegisterService) RegisterUser(ctx context.Context, name string, icon st
 		return nil, err
 	}
 
+	userID, err := uuid.Parse(user.ID)
+	if err != nil {
+		return nil, err
+	}
+
 	err = s.queries.CreateUser(ctx, sqlc.CreateUserParams{
-		UserID:   user.ID,
+		UserID:   userID,
 		UserName: user.Name,
 		IconUrl: sql.NullString{
 			String: user.Icon,
@@ -42,11 +48,15 @@ func (s *RegisterService) RegisterUser(ctx context.Context, name string, icon st
 			Int16: int16(user.Birthday),
 			Valid: true,
 		},
+		RegisteredDate: user.RegisteredAt,
 		LatestLoginDate: sql.NullTime{
 			Time:  user.LatestLoginAt,
 			Valid: true,
 		},
 		StreakLoginDays: int32(user.StreakLogin),
+		RankPoint:       int32(user.RankPoint),
+		Coin:            int32(user.Coin),
+		GachaStone:      int32(user.GachaStone),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/service/register_service.go
+++ b/internal/service/register_service.go
@@ -1,0 +1,56 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/shii-park/friends/internal/domain"
+	"github.com/shii-park/friends/internal/sqlc"
+)
+
+type RegisterService struct {
+	queries *sqlc.Queries
+}
+
+func NewRegisterService(queries *sqlc.Queries) *RegisterService {
+	return &RegisterService{queries: queries}
+}
+
+// RegisterUser はユーザーを生成してDBに保存します
+func (s *RegisterService) RegisterUser(ctx context.Context, name string, icon string, profileMessage string, birthmonth int, birthday int) (*domain.User, error) {
+	user, err := domain.NewUser(name, icon, profileMessage, birthmonth, birthday)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.queries.CreateUser(ctx, sqlc.CreateUserParams{
+		UserID:   user.ID,
+		UserName: user.Name,
+		IconUrl: sql.NullString{
+			String: user.Icon,
+			Valid:  user.Icon != "",
+		},
+		ProfileMessage: sql.NullString{
+			String: user.ProfileMessage,
+			Valid:  user.ProfileMessage != "",
+		},
+		BirthMonth: sql.NullInt16{
+			Int16: int16(user.Birthmonth),
+			Valid: true,
+		},
+		BirthDay: sql.NullInt16{
+			Int16: int16(user.Birthday),
+			Valid: true,
+		},
+		LatestLoginDate: sql.NullTime{
+			Time:  user.LatestLoginAt,
+			Valid: true,
+		},
+		StreakLoginDays: int32(user.StreakLogin),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return user, nil
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,1 +1,0 @@
-package service


### PR DESCRIPTION
<!-- プルリクエストは丁寧に書いてもらうと、あとから見たときに見返しやすいです！ -->
## 概要
ユーザーを新規登録した後，DBに保存とセッションを保存するようにしました
## 変更の理由・背景
- ユーザー情報保存したいので

## 変更内容
- ユーザーデータをDBに保存するRegisterUser()サービス作成
- mainでRegisterServiceのインスタンス生成，RegisterHandler()に渡すように
- RegisterHandler()でRegisterUser()を呼び出し，その後，RegisterHandler()内でセッションを保存

## スクリーンショット（UI変更がある場合）

## 動作確認
- [x] ローカルでビルドが通ることを確認

## レビューしてほしい点・気になっている点
- 

## その他
- 